### PR TITLE
Fix importlib.import_module failing for container directories like src/

### DIFF
--- a/arc/abc/client.py
+++ b/arc/abc/client.py
@@ -1220,29 +1220,29 @@ class Client(t.Generic[AppT], abc.ABC):
 
         return decorator
 
-    def _resolve_import_path(self, path: str) -> tuple[str, str]:  
+    def _resolve_import_path(self, path: str) -> tuple[str, str]:
         """Process container directory and resolve real import path."""
-        components = path.split(".")  
-        importable_components: t.List[str] = []  
-        
-        for _, component in enumerate(components):  
-            test_path = ".".join([*importable_components, component])  
-            try:  
-                importlib.import_module(test_path)  
-                importable_components.append(component)  
-            except ImportError:  
-                continue  
-        
-        if not importable_components:  
-            return components[-1], ""  
-        
-        if len(importable_components) > 1:  
-            pkg = ".".join(importable_components[:-1])  
-            import_path = ".".join(importable_components)  
-        else:  
-            pkg = ""  
-            import_path = importable_components[0]  
-        
+        components = path.split(".")
+        importable_components: t.List[str] = []
+
+        for _, component in enumerate(components):
+            test_path = ".".join([*importable_components, component])
+            try:
+                importlib.import_module(test_path)
+                importable_components.append(component)
+            except ImportError:
+                continue
+
+        if not importable_components:
+            return components[-1], ""
+
+        if len(importable_components) > 1:
+            pkg = ".".join(importable_components[:-1])
+            import_path = ".".join(importable_components)
+        else:
+            pkg = ""
+            import_path = importable_components[0]
+
         return import_path, pkg
 
     def load_extension(self, path: str) -> te.Self:

--- a/arc/abc/client.py
+++ b/arc/abc/client.py
@@ -1220,6 +1220,25 @@ class Client(t.Generic[AppT], abc.ABC):
 
         return decorator
 
+    def _resolve_import_path(self, path: str) -> tuple[str, str]:
+        """Process container directory and resolve real import path."""
+        parents = path.split(".")
+        name = parents.pop()
+
+        if parents:
+            try:
+                importlib.import_module(parents[0])
+                pkg = ".".join(parents)
+                import_path = path
+            except ImportError:
+                pkg = ".".join(parents[1:]) if len(parents) > 1 else ""
+                import_path = ".".join(parents[1:] + [name]) if len(parents) > 1 else name
+        else:
+            pkg = ""
+            import_path = name
+
+        return import_path, pkg
+
     def load_extension(self, path: str) -> te.Self:
         """Load a python module with path `path` as an extension.
         This will import the module, and call it's loader function.
@@ -1260,15 +1279,9 @@ class Client(t.Generic[AppT], abc.ABC):
         - [`Client.load_extensions_from`][arc.client.Client.load_extensions_from]
         - [`Client.unload_extension`][arc.client.Client.unload_extension]
         """
-        parents = path.split(".")
-        name = parents.pop()
+        import_path, pkg = self._resolve_import_path(path)
 
-        pkg = ".".join(parents)
-
-        if pkg:
-            name = "." + name
-
-        module = importlib.import_module(path, package=pkg)
+        module = importlib.import_module(import_path, package=pkg)
 
         loader = getattr(module, "__arc_extension_loader__", None)
 
@@ -1364,13 +1377,7 @@ class Client(t.Generic[AppT], abc.ABC):
         - [`Client.load_extension`][arc.client.Client.load_extension]
         - [`Client.load_extensions_from`][arc.client.Client.load_extensions_from]
         """
-        parents = path.split(".")
-        name = parents.pop()
-
-        pkg = ".".join(parents)
-
-        if pkg:
-            name = "." + name
+        path, pkg = self._resolve_import_path(path)
 
         if path not in self._loaded_extensions:
             raise ExtensionUnloadError(f"Extension '{path}' is not loaded.")


### PR DESCRIPTION
The current extension loading and unloading process cannot properly handle layouts like src/bot (src-layout) or libs/package/src (assuming UV workspaces), resulting in ModuleNotFoundErrors.  
  
This issue affects the `load_extension`, `unload_extension`, and `load_extensions_from` methods. It occurs because `importlib.import_module` attempts to treat container directories (such as `src` and `libs`) as actual Python modules.  
  
This PR fixes the issue by introducing the _resolve_import_path helper function, which resolves paths only after verifying that each directory component is actually importable.  