### PR TITLE
Add support for options defined in type statements

### DIFF
--- a/arc/internal/sigparse.py
+++ b/arc/internal/sigparse.py
@@ -5,6 +5,11 @@ import sys
 import types
 import typing as t
 
+try:
+    from typing import TypeAliasType  # type: ignore
+except ImportError:
+    TypeAliasType = None
+
 import hikari
 
 from arc.abc.option import OptionParams
@@ -273,6 +278,10 @@ def parse_command_signature(  # noqa: C901
 
     for arg_name, hint in hints.items():
         hint: t.Any
+
+        # Resolve hints defined in type statements (available in Python 3.12+)
+        if TypeAliasType is not None and isinstance(hint, TypeAliasType):
+            hint = hint.__value__
 
         # Ignore non-annotated type hints
         if t.get_origin(hint) is not t.Annotated:

--- a/tests/test_sigparse.py
+++ b/tests/test_sigparse.py
@@ -1,4 +1,6 @@
+import contextlib
 import inspect
+import typing as t
 
 import hikari
 import pytest
@@ -177,6 +179,33 @@ def test_ensure_parse_channel_types_has_every_channel_class() -> None:
 def test_ensure_base_channels_has_every_channel_type() -> None:
     for channel_type in hikari.ChannelType:
         assert channel_type in BASE_CHANNEL_TYPE_MAP.values()
+
+
+type_statement_command: t.Callable[t.Concatenate[arc.GatewayContext, ...], t.Awaitable[None]] | None = None
+
+with contextlib.suppress(SyntaxError):
+    exec("""
+type FooOption = arc.Option[str, arc.StrParams("foo")]
+
+async def type_statement_command(
+    ctx: arc.GatewayContext,
+    a: FooOption = "bar"
+) -> None:
+    pass
+""")
+
+
+def test_type_statement_annotation() -> None:
+    if type_statement_command is None:
+        pytest.skip("type statement requires Python 3.12 or newer")
+
+    options = parse_command_signature(type_statement_command)
+    assert len(options) == 1
+
+    assert isinstance(options["a"], arc.command.StrOption)
+    assert options["a"].name == "a"
+    assert options["a"].description == "foo"
+    assert not options["a"].is_required
 
 
 # MIT License


### PR DESCRIPTION
Python 3.12 added lazily evaluated type statements. This change ensures the values of those statements are resolved when parsing command signatures.

This is useful when creating type aliases for options that are repeated across many commands.

Note that this can be done now by defining types without type statements, but this change reduces confusion for users on Python 3.12 or newer who might expect this to just work.